### PR TITLE
Fix/downsample shape check

### DIFF
--- a/src/dlmbl_unet/unet.py
+++ b/src/dlmbl_unet/unet.py
@@ -76,6 +76,7 @@ class Downsample(torch.nn.Module):
         if ndim not in (2, 3):
             msg = f"Invalid number of dimensions: {ndim=}. Options are 2 or 3."
             raise ValueError(msg)
+        self.ndim = ndim
         downops = {2: torch.nn.MaxPool2d, 3: torch.nn.MaxPool3d}
         self.downsample_factor = downsample_factor
 
@@ -100,7 +101,7 @@ class Downsample(torch.nn.Module):
         Returns:
             torch.Tensor: Downsampled tensor.
         """
-        if not self.check_valid(tuple(x.size()[-2:])):
+        if not self.check_valid(tuple(x.size()[-self.ndim :])):
             raise RuntimeError(
                 f"Can not downsample shape {x.size()} with factor {self.downsample_factor}"
             )

--- a/tests/test_dlmbl_unet.py
+++ b/tests/test_dlmbl_unet.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 import torch
 
 import dlmbl_unet
@@ -10,9 +11,56 @@ class TestDown:
         msg = "Your `check_valid` function is not right yet."
         assert down2.check_valid((8, 8)), msg
         assert not down2.check_valid((9, 9)), msg
+        assert not down2.check_valid((9, 8)), msg
+        assert not down2.check_valid((8, 9)), msg
+        down2_3d = dlmbl_unet.Downsample(2, ndim=3)
+        assert down2_3d.check_valid((8, 8, 8)), msg
+        assert not down2_3d.check_valid((9, 9, 9)), msg
+        assert not down2_3d.check_valid((9, 8, 8)), msg
+        assert not down2_3d.check_valid((8, 9, 8)), msg
+        assert not down2_3d.check_valid((8, 8, 9)), msg
         down3 = dlmbl_unet.Downsample(3)
         assert down3.check_valid((9, 9)), msg
         assert not down3.check_valid((8, 8)), msg
+        assert not down3.check_valid((9, 8)), msg
+        assert not down3.check_valid((8, 9)), msg
+        down3_3d = dlmbl_unet.Downsample(3, ndim=3)
+        assert down3_3d.check_valid((9, 9, 9)), msg
+        assert not down3_3d.check_valid((8, 8, 8)), msg
+        assert not down3_3d.check_valid((8, 9, 9)), msg
+        assert not down3_3d.check_valid((9, 8, 9)), msg
+        assert not down3_3d.check_valid((9, 9, 8)), msg
+
+    def test_shape_checker_error(self) -> None:
+        down2 = dlmbl_unet.Downsample(2)
+        with pytest.raises(RuntimeError):
+            x = torch.zeros((2, 4, 7, 8))
+            down2(x)
+        with pytest.raises(RuntimeError):
+            x = torch.zeros((2, 4, 8, 7))
+            down2(x)
+        with pytest.raises(RuntimeError):
+            x = torch.zeros((4, 7, 8))
+            down2(x)
+        down2_3d = dlmbl_unet.Downsample(2, ndim=3)
+        with pytest.raises(RuntimeError):
+            x = torch.zeros((2, 4, 7, 8, 8))
+            down2_3d(x)
+        with pytest.raises(RuntimeError):
+            x = torch.zeros((2, 4, 8, 7, 8))
+            down2_3d(x)
+        with pytest.raises(RuntimeError):
+            x = torch.zeros((2, 4, 8, 8, 7))
+            down2_3d(x)
+        with pytest.raises(RuntimeError):
+            x = torch.zeros((2, 7, 8, 8))
+            down2_3d(x)
+        with pytest.raises(RuntimeError):
+            x = torch.zeros((2, 8, 7, 8))
+            down2_3d(x)
+        with pytest.raises(RuntimeError):
+            x = torch.zeros((2, 8, 8, 7))
+            down2_3d(x)
 
     def test_shape(self) -> None:
         tensor2 = torch.arange(16).reshape((1, 4, 4))


### PR DESCRIPTION
previous version was not correctly checking the shapes for downsampling

specifically, for 3d unets, if the first dimension was not divisible by the downsampling factor it was not throwing a RuntimeError