### PR TITLE
added batchnorm to unet

### DIFF
--- a/src/dlmbl_unet/unet.py
+++ b/src/dlmbl_unet/unet.py
@@ -13,6 +13,7 @@ class ConvBlock(torch.nn.Module):
         kernel_size: int,
         padding: Literal["same", "valid"] = "same",
         ndim: Literal[2, 3] = 2,
+        use_batch_norm: bool = False,
     ):
         """
         Args:
@@ -37,16 +38,18 @@ class ConvBlock(torch.nn.Module):
             msg = f"Invalid number of dimensions: {ndim=}. Options are 2 or 3."
             raise ValueError(msg)
         convops = {2: torch.nn.Conv2d, 3: torch.nn.Conv3d}
+        bnops = {2: torch.nn.BatchNorm2d, 3: torch.nn.BatchNorm3d}
         # define layers in conv pass
         self.conv_pass = torch.nn.Sequential(
-            torch.nn.BatchNorm2d(in_channels, eps=1e-5, momentum=0.05),
             convops[ndim](
                 in_channels, out_channels, kernel_size=kernel_size, padding=padding
             ),
+            bnops[ndim](out_channels, eps=1e-5, momentum=0.05) if use_batch_norm else torch.nn.Identity(),
             torch.nn.ReLU(),
             convops[ndim](
                 out_channels, out_channels, kernel_size=kernel_size, padding=padding
             ),
+            bnops[ndim](out_channels, eps=1e-5, momentum=0.05) if use_batch_norm else torch.nn.Identity(),
             torch.nn.ReLU(),
         )
 

--- a/src/dlmbl_unet/unet.py
+++ b/src/dlmbl_unet/unet.py
@@ -187,6 +187,7 @@ class UNet(torch.nn.Module):
         padding: Literal["same", "valid"] = "same",
         upsample_mode: str = "nearest",
         ndim: Literal[2, 3] = 2,
+        use_batch_norm: bool = False,
     ):
         """A U-Net for 2D or 3D input that expects tensors shaped like:
         ``(batch, channels, height, width)`` or ``(batch, channels, depth, height, width)``,
@@ -244,7 +245,7 @@ class UNet(torch.nn.Module):
             fmaps_in, fmaps_out = self.compute_fmaps_encoder(level)
             self.left_convs.append(
                 ConvBlock(
-                    fmaps_in, fmaps_out, self.kernel_size, self.padding, ndim=ndim
+                    fmaps_in, fmaps_out, self.kernel_size, self.padding, ndim=ndim, use_batch_norm=use_batch_norm
                 )
             )
 

--- a/src/dlmbl_unet/unet.py
+++ b/src/dlmbl_unet/unet.py
@@ -39,6 +39,7 @@ class ConvBlock(torch.nn.Module):
         convops = {2: torch.nn.Conv2d, 3: torch.nn.Conv3d}
         # define layers in conv pass
         self.conv_pass = torch.nn.Sequential(
+            torch.nn.BatchNorm2d(in_channels, eps=1e-5, momentum=0.05),
             convops[ndim](
                 in_channels, out_channels, kernel_size=kernel_size, padding=padding
             ),

--- a/tests/test_dlmbl_unet.py
+++ b/tests/test_dlmbl_unet.py
@@ -73,7 +73,8 @@ class TestDown:
 
 
 class TestConvBlock:
-    def test_shape_valid(self) -> None:
+    @pytest.mark.parametrize('batch_norm', [True, False])
+    def test_shape_valid(self, batch_norm) -> None:
         shape = [20, 30]
         channels = 4
         out_channels = 5
@@ -82,7 +83,7 @@ class TestConvBlock:
 
         tensor_in = torch.ones([n_batch, channels, *shape])
         conv = dlmbl_unet.ConvBlock(
-            channels, out_channels, kernel_size, padding="valid"
+            channels, out_channels, kernel_size, padding="valid", use_batch_norm=batch_norm
         )
         tensor_out = conv(tensor_in)
 
@@ -91,7 +92,8 @@ class TestConvBlock:
         msg = "Output shape for valid padding is incorrect."
         assert tensor_out.shape == torch.Size(shape_expected), msg
 
-    def test_shape_same(self) -> None:
+    @pytest.mark.parametrize('batch_norm', [True, False])
+    def test_shape_same(self, batch_norm) -> None:
         shape = [16, 39]
         channels = 4
         out_channels = 5
@@ -99,7 +101,7 @@ class TestConvBlock:
         n_batch = 1
 
         tensor_in = torch.ones([n_batch, channels, *shape])
-        conv = dlmbl_unet.ConvBlock(channels, out_channels, kernel_size, padding="same")
+        conv = dlmbl_unet.ConvBlock(channels, out_channels, kernel_size, padding="same", use_batch_norm=batch_norm)
         tensor_out = conv(tensor_in)
 
         shape_expected = [n_batch, out_channels, *shape]
@@ -150,7 +152,8 @@ class TestUNet:
         msg = "The computation of number of feature maps in the decoder is incorrect for level 0"
         assert unet.compute_fmaps_decoder(0) == (85, 17), msg
 
-    def test_shape_valid_2d(self) -> None:
+    @pytest.mark.parametrize('batch_norm', [True, False])
+    def test_shape_valid_2d(self, batch_norm) -> None:
         unetvalid = dlmbl_unet.UNet(
             depth=4,
             in_channels=2,
@@ -160,13 +163,15 @@ class TestUNet:
             downsample_factor=3,
             kernel_size=5,
             padding="valid",
+            use_batch_norm=batch_norm
         )
         msg = "The output shape of your UNet is incorrect for valid padding."
         assert unetvalid(torch.ones((2, 2, 536, 536))).shape == torch.Size(
             (2, 7, 108, 108)
         ), msg
 
-    def test_shape_valid_3d(self) -> None:
+    @pytest.mark.parametrize('batch_norm', [True, False])
+    def test_shape_valid_3d(self, batch_norm) -> None:
         unetvalid = dlmbl_unet.UNet(
             depth=3,
             in_channels=2,
@@ -177,13 +182,15 @@ class TestUNet:
             kernel_size=5,
             padding="valid",
             ndim=3,
+            use_batch_norm=batch_norm
         )
         msg = "The output shape of your UNet is incorrect for valid padding in 3D."
         assert unetvalid(torch.ones((2, 2, 158, 158, 158))).shape == torch.Size(
             (2, 1, 18, 18, 18)
         ), msg
 
-    def test_shape_same_2d(self) -> None:
+    @pytest.mark.parametrize('batch_norm', [True, False])
+    def test_shape_same_2d(self, batch_norm) -> None:
         unetsame = dlmbl_unet.UNet(
             depth=4,
             in_channels=2,
@@ -193,13 +200,15 @@ class TestUNet:
             downsample_factor=3,
             kernel_size=5,
             padding="same",
+            use_batch_norm=batch_norm
         )
         msg = "The output shape of your Unet is incorrect for same padding."
         assert unetsame(torch.ones((2, 2, 243, 243))).shape == torch.Size(
             (2, 7, 243, 243)
         ), msg
 
-    def test_shape_same_3d(self) -> None:
+    @pytest.mark.parametrize('batch_norm', [True, False])
+    def test_shape_same_3d(self, batch_norm) -> None:
         unetsame = dlmbl_unet.UNet(
             depth=3,
             in_channels=2,
@@ -210,6 +219,7 @@ class TestUNet:
             kernel_size=5,
             padding="same",
             ndim=3,
+            use_batch_norm=batch_norm
         )
         msg = "The output shape of your Unet is incorrect for same padding."
         assert unetsame(torch.ones((2, 2, 27, 27, 27))).shape == torch.Size(

--- a/tests/test_dlmbl_unet.py
+++ b/tests/test_dlmbl_unet.py
@@ -78,15 +78,16 @@ class TestConvBlock:
         channels = 4
         out_channels = 5
         kernel_size = 7
+        n_batch = 1
 
-        tensor_in = torch.ones([channels, *shape])
+        tensor_in = torch.ones([n_batch, channels, *shape])
         conv = dlmbl_unet.ConvBlock(
             channels, out_channels, kernel_size, padding="valid"
         )
         tensor_out = conv(tensor_in)
 
         shape_expected = list(np.array(shape) - 2 * (kernel_size - 1))
-        shape_expected = [out_channels, *shape_expected]
+        shape_expected = [n_batch, out_channels, *shape_expected]
         msg = "Output shape for valid padding is incorrect."
         assert tensor_out.shape == torch.Size(shape_expected), msg
 
@@ -95,17 +96,18 @@ class TestConvBlock:
         channels = 4
         out_channels = 5
         kernel_size = 7
+        n_batch = 1
 
-        tensor_in = torch.ones([channels, *shape])
+        tensor_in = torch.ones([n_batch, channels, *shape])
         conv = dlmbl_unet.ConvBlock(channels, out_channels, kernel_size, padding="same")
         tensor_out = conv(tensor_in)
 
-        shape_expected = [out_channels, *shape]
+        shape_expected = [n_batch, out_channels, *shape]
         msg = "Output shape for same padding is incorrect."
         assert tensor_out.shape == torch.Size(shape_expected), msg
 
     def test_relu(self) -> None:
-        shape = [1, 100, 100]
+        shape = [1, 1, 100, 100]
         tensor_in = torch.randn(shape) * 2
 
         conv = dlmbl_unet.ConvBlock(1, 50, 5, padding="same")

--- a/tests/test_dlmbl_unet.py
+++ b/tests/test_dlmbl_unet.py
@@ -225,3 +225,34 @@ class TestUNet:
         assert unetsame(torch.ones((2, 2, 27, 27, 27))).shape == torch.Size(
             (2, 1, 27, 27, 27)
         ), msg
+
+
+    @pytest.mark.parametrize('batch_norm', [True, False])
+    def test_has_batch_norm_2d(self, batch_norm):
+        unet = dlmbl_unet.UNet(
+            depth=3,
+            in_channels=2,
+            ndim=2,
+            use_batch_norm=batch_norm
+        )
+        if batch_norm:
+            module_types = [type(m) for m in unet.modules()]
+            assert torch.nn.BatchNorm2d in module_types
+        else:
+            module_types = [type(m) for m in unet.modules()]
+            assert torch.nn.BatchNorm2d not in module_types
+
+    @pytest.mark.parametrize('batch_norm', [True, False])
+    def test_has_batch_norm_3d(self, batch_norm):
+        unet = dlmbl_unet.UNet(
+            depth=3,
+            in_channels=2,
+            ndim=3,
+            use_batch_norm=batch_norm
+        )
+        if batch_norm:
+            module_types = [type(m) for m in unet.modules()]
+            assert torch.nn.BatchNorm3d in module_types
+        else:
+            module_types = [type(m) for m in unet.modules()]
+            assert torch.nn.BatchNorm3d not in module_types


### PR DESCRIPTION
Added batchnorm before convolutions, and set the UNet to not use them by default. Tested with `03_segmentation` module and looks correct, although performance wasn't as good as without batchnorm. Added tests for batchnorm components. 